### PR TITLE
Compare userguide from branch (generation compatibility)

### DIFF
--- a/.github/workflows/diff_user_guides.yml
+++ b/.github/workflows/diff_user_guides.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   pull_request_target:
     paths:
-      - "docs/user_guide/templates/**" # Only run the workflow if files in this folder are changed
+      - "docs/user_guide/**" # Only run the workflow if files in this folder are changed
       - "docs-examples/inject_file/src" # Only run the workflow if files in this folder are changed
 
 jobs:

--- a/.github/workflows/diff_user_guides.yml
+++ b/.github/workflows/diff_user_guides.yml
@@ -1,0 +1,97 @@
+name: Compare generated user guides
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request_target:
+    paths:
+      - "docs/user_guide/templates/**" # Only run the workflow if files in this folder are changed
+      - "docs-examples/inject_file/src" # Only run the workflow if files in this folder are changed
+
+jobs:
+  compare-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }} # PR repository
+          ref: ${{ github.head_ref }} # PR branch
+
+      - name: Generate files for PR branch
+        run: |
+          ./generate_user_guides.sh || true
+
+      - name: Move PR generated files
+        run: mkdir -p /tmp/pr_generated && mv docs/user_guide/* /tmp/pr_generated/ && mv /tmp/pr_generated/templates docs/user_guide/
+
+      - name: Checkout target branch
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.base.repo.full_name }} # Upstream repository
+          ref: ${{ github.base_ref }} # Target branch
+
+      - name: Generate files for target branch
+        run: |
+          ./generate_user_guides.sh || true
+
+      - name: Move target generated files
+        run: mkdir -p /tmp/target_generated && mv docs/user_guide/* /tmp/target_generated/ && mv /tmp/target_generated/templates docs/user_guide/ ||  true
+
+      # Step 6: Compare files
+      - name: Compare generated files
+        id: compare
+        run: |
+          diff -r /tmp/target_generated/ /tmp/pr_generated/ > comparison_result.diff || true
+
+      # Step 7: Post comparison results as a comment
+      - name: Post PR comment with comparison results
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const comparisonResult = fs.readFileSync('comparison_result.diff', 'utf8');
+
+            // List all comments
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // Delete previous bot comments
+            for (const comment of comments.data) {
+              if (comment.user.login === 'github-actions[bot]' && comment.body.startsWith('### Comparison Result')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+
+            // Construct the workflow run link
+            const runLink = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            // Create the comment body
+            const commentBody = 
+              `### Comparison Result\n\n` +
+              `[View workflow run details](${runLink})` +
+              `<details><summary>Userguide diff introduced by this PR</summary>\n` +
+              `<p>\n\n` +
+              `\`\`\`diff\n` +
+              `${comparisonResult}\n` +
+              `\`\`\`\n\n` ;
+              `</p>\n` +
+              `</details>`;
+
+            // Post new comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody,
+            });

--- a/.github/workflows/diff_user_guides.yml
+++ b/.github/workflows/diff_user_guides.yml
@@ -25,7 +25,7 @@ jobs:
           ./generate_user_guides.sh || true
 
       - name: Move PR generated files
-        run: mkdir -p /tmp/pr_generated && mv docs/user_guide/* /tmp/pr_generated/ && mv /tmp/pr_generated/templates docs/user_guide/
+        run: mkdir -p /tmp/pr_generated && mv docs/user_guide/* /tmp/pr_generated/ && mv /tmp/pr_generated/templates docs/user_guide/ || true
 
       - name: Checkout target branch
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
           ./generate_user_guides.sh || true
 
       - name: Move target generated files
-        run: mkdir -p /tmp/target_generated && mv docs/user_guide/* /tmp/target_generated/ && mv /tmp/target_generated/templates docs/user_guide/ ||  true
+        run: mkdir -p /tmp/target_generated && mv docs/user_guide/* /tmp/target_generated/ && mv /tmp/target_generated/templates docs/user_guide/ || true
 
       # Step 6: Compare files
       - name: Compare generated files


### PR DESCRIPTION
This PR enables to easily see modifications made to user guides, without having to run diff scripts locally

- While this PR doesn´t change add much features compared to github's builtin diff, but will be useful for https://github.com/dimforge/parry.rs/pull/2 which now generates the user guide.

This uses `pull_request_target`, which runs the CI on the base (target) repository, opposed to `pull_request` which runs on the fork repository. That's by github's design to limit security concerns, so we can use github token to comment.

:warning: This is still an advanced technique which will require some care on future PRs, because we're running external code from the PR.

- For a minimal example, see https://github.com/Vrixyz/parry.rs/pull/7#issuecomment-2491442397.
- For real use-cases examples, see:
  - https://github.com/Vrixyz/parry.rs/pull/1#issuecomment-2491287350
  - https://github.com/Vrixyz/parry.rs/pull/6#issuecomment-2491413117

Note this new CI step doesn´t run for this PR, because:
- `pull_request_target` doesn't exist in the target branch, so it won't run.
- This could run if we used `pull_request`, but we wouldn't be able to comment h ere (a different repository from the PR branch.
- I didn´t modify anything in the watched path.